### PR TITLE
Make binary distribution configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,11 @@ azure-devops = { project = "alecmocatta/constellation", pipeline = "tests" }
 maintenance = { status = "actively-developed" }
 
 [features]
+default = ["distribute_binaries"]
+nightly = ["palaver/nightly", "relative/nightly"]
+distribute_binaries = ["constellation-internal/distribute_binaries"]
 fringe = ["serde_pipe/fringe"]
 no_alloc = ["constellation-internal/no_alloc"]
-nightly = ["palaver/nightly", "relative/nightly"]
 
 [dependencies]
 constellation-internal = { path = "constellation-internal", version = "=0.1.2" }
@@ -39,7 +41,6 @@ docopt = "1.0"
 either = "1.5"
 futures-preview = "0.3.0-alpha.18"
 log = "0.4"
-more-asserts = "0.2"
 notifier = { version = "0.1", features = ["tcp_typed"] }
 once_cell = { version = "0.2", default-features = false }
 palaver = "0.2"
@@ -70,9 +71,9 @@ sha1 = "0.6"
 systemstat = "0.1"
 
 [patch.crates-io]
-# bincode = { git = "https://github.com/alecmocatta/bincode" }
 systemstat = { git = "https://github.com/alecmocatta/systemstat" }
 serde_traitobject = { git = "https://github.com/alecmocatta/serde_traitobject", branch = "ergo-impls" }
+palaver = { git = "https://github.com/alecmocatta/palaver", branch = "fexecve-noalloc" }
 
 # Hopefully we won't need to exhaustively list in future:
 # https://github.com/rust-lang/cargo/issues/5766 or https://github.com/rust-lang/rust/issues/50297

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ futures-preview = "0.3.0-alpha.18"
 log = "0.4"
 notifier = { version = "0.1", features = ["tcp_typed"] }
 once_cell = { version = "0.2", default-features = false }
-palaver = "0.2"
+palaver = "0.2.8"
 pin-utils = "0.1.0-alpha.4"
 rand = "0.7"
 relative = "0.1"
@@ -71,9 +71,8 @@ sha1 = "0.6"
 systemstat = "0.1"
 
 [patch.crates-io]
-systemstat = { git = "https://github.com/alecmocatta/systemstat" }
 serde_traitobject = { git = "https://github.com/alecmocatta/serde_traitobject", branch = "ergo-impls" }
-palaver = { git = "https://github.com/alecmocatta/palaver", branch = "fexecve-noalloc" }
+systemstat = { git = "https://github.com/alecmocatta/systemstat" }
 
 # Hopefully we won't need to exhaustively list in future:
 # https://github.com/rust-lang/cargo/issues/5766 or https://github.com/rust-lang/rust/issues/50297

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,14 +17,14 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-08-08
+      rust_lint_toolchain: nightly-2019-08-15
       rust_flags: ''
-      rust_features: 'no_alloc'
+      rust_features: 'no_alloc;no_alloc distribute_binaries'
       rust_target_check: ''
       rust_target_build: ''
       rust_target_run: ''
-      rust_test_flags: '--test tester -- 100 --no-default-features --features "$FEATURES" $ALL_FEATURES'
-      rust_test_release_flags: '--test tester -- 100 --no-default-features --features "$FEATURES" $ALL_FEATURES --release'
+      rust_test_flags: '--test tester -- 50 --no-default-features --features "$FEATURES" $ALL_FEATURES'
+      rust_test_release_flags: '--test tester -- 50 --no-default-features --features "$FEATURES" $ALL_FEATURES --release'
     matrix:
       # windows:
       #   imageName: 'vs2017-win2016'

--- a/constellation-internal/Cargo.toml
+++ b/constellation-internal/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/constellation-internal/0.1.2"
 edition = "2018"
 
 [features]
+distribute_binaries = []
 no_alloc = ["alloc_counter"]
 
 [dependencies]

--- a/constellation-internal/src/lib.rs
+++ b/constellation-internal/src/lib.rs
@@ -30,7 +30,7 @@ use nix::{fcntl, sys::signal, unistd};
 use palaver::file::{copy, memfd_create};
 use serde::{Deserialize, Serialize};
 use std::{
-	convert::TryInto, env, ffi::{CString, OsString}, fmt::{self, Debug, Display}, fs::File, io::{self, Read}, net, ops, os::unix::{
+	convert::TryInto, env, ffi::{CString, OsString}, fmt::{self, Debug, Display}, fs::File, io::{self, Read, Seek}, net, ops, os::unix::{
 		ffi::OsStringExt, io::{AsRawFd, FromRawFd}
 	}, sync::{Arc, Mutex}
 };
@@ -606,7 +606,7 @@ pub fn file_from_reader<R: Read>(
 	);
 	unistd::ftruncate(file.as_raw_fd(), len.try_into().unwrap()).unwrap();
 	copy(reader, &mut file, len)?;
-	let x = unistd::lseek(file.as_raw_fd(), 0, unistd::Whence::SeekSet).unwrap();
+	let x = file.seek(io::SeekFrom::Start(0)).unwrap();
 	assert_eq!(x, 0);
 	Ok(file)
 }

--- a/src/bin/deploy.rs
+++ b/src/bin/deploy.rs
@@ -89,8 +89,11 @@ fn main() {
 		.unwrap_or_else(|e| panic!("Could not connect to {:?}: {:?}", bridge_address, e));
 	let (mut stream_read, mut stream_write) =
 		(BufferedStream::new(&stream), BufferedStream::new(&stream));
+	#[cfg(feature = "distribute_binaries")]
 	let binary =
 		fs::File::open(&path).unwrap_or_else(|e| panic!("Couldn't open file {:?}: {:?}", path, e));
+	#[cfg(not(feature = "distribute_binaries"))]
+	let binary = std::marker::PhantomData::<fs::File>;
 	let request = BridgeRequest {
 		resources: None,
 		args,


### PR DESCRIPTION
The `distribute_binaries` feature is enabled by default. When disabled, binaries aren't sent over the network; instead they're read from the filesystem (which probably implies running all on the same machine).